### PR TITLE
Disparar evento al crear una nueva organización.

### DIFF
--- a/modules/organizations/README.md
+++ b/modules/organizations/README.md
@@ -28,3 +28,11 @@ erDiagram
 ## Dependencias
 
 Este módulo no depende, al momento, de ningun otro módulo.
+
+## Eventos
+
+Este módulo dispara los siguientes eventos:
+
+| Evento | Disparador | Parámetros |
+|--------| ----- | ---- |
+| `organizations.new` | Al crear una nueva organización. | [Organization](src/Entities/Organization.php) `$newOrg`

--- a/modules/organizations/src/Controllers/CreateOrganizationController.php
+++ b/modules/organizations/src/Controllers/CreateOrganizationController.php
@@ -3,6 +3,7 @@
 namespace Percontmx\SportsCloud\Organizations\Controllers;
 
 use App\Controllers\BaseController;
+use CodeIgniter\Events\Events;
 use Percontmx\SportsCloud\Organizations\Entities\Organization;
 use Percontmx\SportsCloud\Organizations\Services\OrganizationsService;
 
@@ -21,10 +22,13 @@ class CreateOrganizationController extends BaseController
 
     public function index()
     {
-        
-        $data = $this->request->getPost();
+        $data = [
+            'full_name' => $this->request->getPost('full_name'),
+            'short_name' => $this->request->getPost('short_name')
+        ];
+        $this->logger->info('Intentando crear una organización con los siguientes datos: ' . 
+            json_encode($data));
 
-        
         if (!$this->validateData($data, $this->rules)) {
             $errors = $this->validator->getErrors();
             $this->logger->error('Validation errors: ' . json_encode($errors));
@@ -46,6 +50,7 @@ class CreateOrganizationController extends BaseController
         $createdOrg = $organizationsService->createOrganization($newOrg);
 
         $this->logger->info('Organización creada con ID: ' . $createdOrg->id);
+        Events::trigger('organizations.new', $createdOrg);
         // TODO Definir respuesta
         return view('Percontmx\SportsCloud\Organizations\Views\OrganizationsForm'); 
     }

--- a/modules/organizations/tests/events/CreateOrganizationEventTest.php
+++ b/modules/organizations/tests/events/CreateOrganizationEventTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use CodeIgniter\Events\Events;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+use Percontmx\SportsCloud\Organizations\Entities\Organization;
+use PHPUnit\Framework\Attributes\Test;
+
+class CreateOrganizationEventTest extends CIUnitTestCase
+{
+
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+
+    protected $refresh = true;
+    protected $namespace = 'Percontmx\SportsCloud\Organizations';
+    protected $migrate = true;
+    protected $migrateOnce = false;
+
+    private static $data = [
+        'full_name' => 'National Basketball Association',
+        'short_name' => 'NBA'
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function createOrganizationEventTriggered(): void 
+    {
+        Events::on('organizations.new', function(Organization $organization) {
+            $this->assertInstanceOf(Organization::class, $organization);
+            $this->assertEquals(self::$data['full_name'], $organization->full_name);
+            $this->assertEquals(self::$data['short_name'], $organization->short_name);
+            $this->assertEquals('admin', $organization->created_by);
+        });
+
+        $response = $this->withHeaders([
+            'Content-Type' => 'application/x-www-form-urlencoded'
+        ])->post('/organizations', self::$data);
+
+        $response->assertOK();
+    }
+}


### PR DESCRIPTION
Dispara un evento con nombre `organizations.new` después de guardar la organización nueva, para que otros elementos del sistema la puedan tomar.

Se incluye prueba unitaria.

closes #17 